### PR TITLE
refactor: Set default value for schema overrides

### DIFF
--- a/.github/cspell.json
+++ b/.github/cspell.json
@@ -26,7 +26,8 @@
     "upserting",
     "preconfigured",
     "Khuwn",
-    "Soulutions"
+    "Soulutions",
+    "Codacy"
   ],
   "ignoreWords": [
     "realtime"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![style: very good analysis][very_good_analysis_badge]][very_good_analysis_link]
 [![License: MIT][license_badge]][license_link]
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/bf5235675f5f4d769f959ddc797ed998)](https://app.codacy.com/gh/Khuwn-Soulutions/supabase_codegen/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
 A comprehensive suite of packages for generating type-safe Dart models from Supabase databases, supporting both pure Dart and Flutter applications.
 

--- a/packages/supabase_codegen/lib/src/generator/generate_supabase_types.dart
+++ b/packages/supabase_codegen/lib/src/generator/generate_supabase_types.dart
@@ -86,7 +86,7 @@ class SupabaseCodeGenerator {
     bool forFlutter = false,
 
     /// Overrides for table and column configurations
-    SchemaOverrides? overrides,
+    SchemaOverrides overrides = const {},
   }) async {
     /// Set tag
     tag = fileTag;
@@ -101,7 +101,7 @@ class SupabaseCodeGenerator {
     forFlutterUsage = forFlutter;
 
     /// Set overrides
-    schemaOverrides = overrides ?? {};
+    schemaOverrides = overrides;
 
     /// Load env keys
     final dotenv = DotEnv()..load([envFilePath]);

--- a/packages/supabase_codegen/test/src/generators/generate_supabase_types_test.dart
+++ b/packages/supabase_codegen/test/src/generators/generate_supabase_types_test.dart
@@ -25,7 +25,8 @@ void main() {
     });
 
     group('with env file', () {
-      final envPath = path.join(Directory.current.path, 'test', '.env');
+      final envPath =
+          path.join(Directory.current.path, 'test', '.env-gen-test');
       late File envFile;
 
       setUp(() => envFile = File(envPath));

--- a/packages/supabase_codegen/test/src/generators/generate_types/run_generate_types_test.dart
+++ b/packages/supabase_codegen/test/src/generators/generate_types/run_generate_types_test.dart
@@ -32,6 +32,7 @@ void main() {
           fileTag: any(named: 'fileTag'),
           skipFooter: any(named: 'skipFooter'),
           forFlutter: any(named: 'forFlutter'),
+          overrides: any(named: 'overrides'),
         ),
       ).thenAnswer((_) async => {});
     });


### PR DESCRIPTION
## Status

**READY**

## Description

This PR refactors the `generateSupabaseTypes` method to provide a default empty map for the `overrides` parameter. This simplifies the code by removing the need for null checks.

### Key Changes:
-   Updated the `generateSupabaseTypes` method signature to set a default value for `overrides`.
-   Updated tests to reflect the change in the method signature and to use a more specific environment file for testing.

## Type of Change

- [x] 🧹 Code refactor