### PR TITLE
fix: ignoring analysis errors

### DIFF
--- a/packages/supabase_codegen/lib/src/generator/generators/generate_header_footer.dart
+++ b/packages/supabase_codegen/lib/src/generator/generators/generate_header_footer.dart
@@ -38,7 +38,10 @@ void writeHeader(
       ..writeln(commentPrefix)
       ..writeln(
           '$_ignoreCommentPrefix ignore_for_file: require_trailing_commas, '
-          'constant_identifier_names');
+          'constant_identifier_names')
+      ..writeln(
+        '$_ignoreCommentPrefix ignore_for_file: dangling_library_doc_comments',
+      );
   }
   buffer.writeln(commentPrefix);
 }


### PR DESCRIPTION
## Status

**READY**

## Description

Fixes the analysis errors that may occur in a generated file despite the ignore_for_file comments because a triple slash was previously used on the line.

Also added an ignore for dangling comments error

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)