### PR TITLE
fix: brick partials symlinks

### DIFF
--- a/packages/supabase_codegen_templates/barrel_files/__brick__/{{~ footer }}
+++ b/packages/supabase_codegen_templates/barrel_files/__brick__/{{~ footer }}
@@ -1,1 +1,1 @@
-/Users/jermaine/Documents/dev/github/supabase_codegen/packages/supabase_codegen_templates/partials/{{~ footer }}
+../../partials/{{~ footer }}

--- a/packages/supabase_codegen_templates/barrel_files/__brick__/{{~ header }}
+++ b/packages/supabase_codegen_templates/barrel_files/__brick__/{{~ header }}
@@ -1,1 +1,1 @@
-/Users/jermaine/Documents/dev/github/supabase_codegen/packages/supabase_codegen_templates/partials/{{~ header }}
+../../partials/{{~ header }}

--- a/packages/supabase_codegen_templates/tables_and_enums/__brick__/{{~ footer }}
+++ b/packages/supabase_codegen_templates/tables_and_enums/__brick__/{{~ footer }}
@@ -1,1 +1,1 @@
-/Users/jermaine/Documents/dev/github/supabase_codegen/packages/supabase_codegen_templates/partials/{{~ footer }}
+../../partials/{{~ footer }}

--- a/packages/supabase_codegen_templates/tables_and_enums/__brick__/{{~ header }}
+++ b/packages/supabase_codegen_templates/tables_and_enums/__brick__/{{~ header }}
@@ -1,1 +1,1 @@
-/Users/jermaine/Documents/dev/github/supabase_codegen/packages/supabase_codegen_templates/partials/{{~ header }}
+../../partials/{{~ header }}

--- a/packages/supabase_codegen_templates/tables_and_enums/__brick__/{{~ table.row.field.array }}
+++ b/packages/supabase_codegen_templates/tables_and_enums/__brick__/{{~ table.row.field.array }}
@@ -1,1 +1,1 @@
-/Users/jermaine/Documents/dev/github/supabase_codegen/packages/supabase_codegen_templates/partials/{{~ table.row.field.array }}
+../../partials/{{~ table.row.field.array }}

--- a/packages/supabase_codegen_templates/tables_and_enums/__brick__/{{~ table.row.field.single }}
+++ b/packages/supabase_codegen_templates/tables_and_enums/__brick__/{{~ table.row.field.single }}
@@ -1,1 +1,1 @@
-/Users/jermaine/Documents/dev/github/supabase_codegen/packages/supabase_codegen_templates/partials/{{~ table.row.field.single }}
+../../partials/{{~ table.row.field.single }}


### PR DESCRIPTION

## Status

**READY**

## Description

The symlinks of the brick partials were done as absolute paths not relative paths. This PR fixes that to ensure it will work on any machine.

## Type of Change
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)