### PR TITLE
fix(codegen): add support for Windows path separators in `extractPath()`

### DIFF
--- a/packages/supabase_codegen/bin/add_codegen_functions.dart
+++ b/packages/supabase_codegen/bin/add_codegen_functions.dart
@@ -119,7 +119,7 @@ Future<void> addCodegenFunctionsMigration({
 /// Extract the path from the given [input]
 String extractPath(String input) {
   // Define a regular expression to match the path
-  final pathRegExp = RegExp(r'\b\w+/\w+/\d+_\w+\.sql\b');
+  final pathRegExp = RegExp(r'\b\w+[/\\]\w+[/\\]\d+_\w+\.sql\b');
 
   // Find the match in the input string
   final Match? match = pathRegExp.firstMatch(input);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

The `extractPath` regex in `add_codegen_functions.dart` only matched Unix-style forward slashes (`/`), causing path extraction to fail on Windows where backslashes (`\`) are used as path separators.

Updated the regex pattern from:
```
\b\w+/\w+/\d+_\w+\.sql\b
```
to:
```
\b\w+[/\\]\w+[/\\]\d+_\w+\.sql\b
```

This ensures migration SQL file paths are correctly extracted on both Unix and Windows systems.


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL file path detection to recognize both Windows (`\`) and Unix-style (`/`) directory separators, enhancing cross-platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->